### PR TITLE
fix: broken styling in CardSet block

### DIFF
--- a/src/components/Blocks/CardSet/CardSet.module.scss
+++ b/src/components/Blocks/CardSet/CardSet.module.scss
@@ -1,27 +1,37 @@
 .cardSetContainer {
-    width: 100vw;
-    overflow-x: hidden;
-    background-color: #E9F5ff;
+    position: relative;
+    width: 100%;
     padding-top: 95px;
     padding-bottom: 133px;
     margin-top: 50px;
+    text-align: center;
+    z-index: 5;
+
+    & * {
+        z-index: 5;
+    }
 }
 
 .cards {
     display: flex;
     flex-direction: row;
     justify-content: center;
-    gap: 75px;
-    width: 100vw;
+    gap: 5vw;
 }
 
-@media ( screen and max-width: 600px ) {
+@media ( screen and max-width: 800px ) {
     .cards {
         flex-direction: column;
         align-items: center;
     }
 }
 
-.cardSetContainer {
-    text-align: center;
+.backgroundCover {
+    position: absolute;
+    background-color: #E9F5ff;
+    width: 200vw;
+    height: 100%;
+    top: 0;
+    left: -50vw;
+    z-index: 3;
 }

--- a/src/components/Blocks/CardSet/CardSet.tsx
+++ b/src/components/Blocks/CardSet/CardSet.tsx
@@ -13,6 +13,7 @@ export const CardSet = ({ volunteerCard, partnerCard }: ICardSet) => {
                 {volunteerCard}
                 {partnerCard}
             </div>
+            <div className={styles.backgroundCover}/>
         </div>
     );
 };

--- a/src/components/Blocks/CardSet/components/Card/Card.module.scss
+++ b/src/components/Blocks/CardSet/components/Card/Card.module.scss
@@ -23,7 +23,6 @@
 }
 
 @media (screen and max-width: 600px){
-
     .cardContainer{
         width: 70vw;
     }

--- a/styles/pages/Home.module.scss
+++ b/styles/pages/Home.module.scss
@@ -2,7 +2,7 @@
 @import '../_variables';
 
 .pageWrapper {
-    margin: 200px 206px 0 206px;
+    margin: 200px 15vw 0 15vw;
 
     @media screen and (max-width: 600px) {
         margin: 200px 10vw 0 10vw;


### PR DESCRIPTION
I moved some of the page padding to the Layout component. This caused the CardSet block to no longer have a full-width colored backaground. I fixed this here. I also increased the breakpoint where the cards flip to column orientation.