### PR TITLE
fix: broken IconSet styling on narrow screens

### DIFF
--- a/src/components/Blocks/IconSet/IconSet.module.scss
+++ b/src/components/Blocks/IconSet/IconSet.module.scss
@@ -4,5 +4,6 @@
 
 .iconWrapper {
     display: flex;
+    flex-wrap: wrap;
     justify-content: center;
 }

--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -4,7 +4,7 @@ import styles from '@/styles/pages/About.module.scss';
 
 export default function About(): JSX.Element {
     return (
-        <div className={styles.container}>
+        <div className={styles.pageWrapper}>
             <h1>About Us</h1>
             <IconSet />
             <p>

--- a/styles/pages/About.module.scss
+++ b/styles/pages/About.module.scss
@@ -1,7 +1,12 @@
-.container {
+.pageWrapper {
     display: flex;
     flex-direction: column;
     align-items: center;
+    margin: 200px 15vw 0 15vw;
+
+    @media screen and (max-width: 600px) {
+        margin: 25vh 10vw 0 10vw;
+    }
 
     h1 {
         font-family: 'Roboto', sans-serif;

--- a/styles/pages/Volunteer.module.scss
+++ b/styles/pages/Volunteer.module.scss
@@ -1,5 +1,5 @@
 .pageWrapper {
-    margin: 200px 206px 0 206px;
+    margin: 200px 15vw 0 15vw;
 
     @media screen and (max-width: 600px) {
         margin: 25vh 10vw 0 10vw;


### PR DESCRIPTION
improve page padding at /volunteer and /about.

Enable wrapping of the IconSet when it's too long for its container.