### PR TITLE
feat: added docs to the nav bar, fixed alignment on about us

### DIFF
--- a/src/components/Blocks/IconSet/IconSet.module.scss
+++ b/src/components/Blocks/IconSet/IconSet.module.scss
@@ -1,5 +1,5 @@
 .container {
-    width: 60%;
+    width: 80%;
     margin: 0 auto;
 }
 
@@ -7,5 +7,4 @@
     display: flex;
     flex-wrap: wrap;
     justify-content: space-around;
-    gap: 15px;
 }

--- a/src/components/Blocks/IconSet/components/Icon.module.scss
+++ b/src/components/Blocks/IconSet/components/Icon.module.scss
@@ -2,6 +2,8 @@
     display: flex;
     flex-direction: column;
     align-items: center;
+    width: 180px;
+    margin-bottom: 3.5rem;
 
     .imageWrapper {
         border-radius: 50%;

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -83,6 +83,7 @@ export function Navbar(): JSX.Element {
                 )}
                 <SmartLink to="/about">About</SmartLink>
                 <SmartLink to="/code-of-conduct">Code of Conduct</SmartLink>
+                <SmartLink to="https://docs.opensgf.org/s/public-docs">Docs</SmartLink>
                 <Button href="https://discord.gg/jFD8dZP" text="Join" />
             </div>
             <div onClick={() => setOpen(!open)} className={styles.hamburgerWrapper}>


### PR DESCRIPTION
Heyo! Just as it says. The Co-Organizer icons weren't centered on the about us page correctly, so I fixed that. 